### PR TITLE
fix: ルート重複エラー修正とLP文言更新

### DIFF
--- a/resources/views/landing.blade.php
+++ b/resources/views/landing.blade.php
@@ -358,14 +358,14 @@
         <div class="hero-content">
             <h1 class="hero-title">
                 行きたい、また行きたい——<br>
-                ただそれだけを、そっと記す。
+                2つの「行きたい」を、一つに記す。
             </h1>
             <p class="hero-subtitle">
-                TasteRetreatは、あなたの食体験を磨く小さな額縁です。
+                TasteRetreatは、あなたの食体験を導く小さな羅針盤です。
             </p>
             <div class="hero-buttons">
                 <a href="{{ route('login') }}" class="btn btn-primary">ログインして始める</a>
-                <a href="#how" class="btn btn-outline">詳細を見る</a>
+                <a href="#how" class="btn btn-outline">概要を見る</a>
 
             </div>
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -66,15 +66,10 @@ Route::get('/test-lp', function () {
 // ホームルート（認証必要 - 元の設計通り）
 Route::get('/home', [PostController::class, 'index'])->middleware(['auth'])->name('home');
 
-// ランディングページ（認証不要）
+// ランディングページ（認証不要）- /landingパスでのアクセス用
 Route::get('/landing', function () {
     return view('landing');
-})->name('landing');
-
-// ランディングページ（認証不要）
-Route::get('/landing', function () {
-    return view('landing');
-})->name('landing');
+})->name('landing.page');
 
 Route::get('/dashboard', function () {
     return view('dashboard');


### PR DESCRIPTION
- /landingルートの重複を解消（landing.pageに名前変更）
- LP H1テキスト修正（lp-brief.md準拠）
- LP サブタイトル：羅針盤に変更
- CTAボタン：概要を見るに変更

🤖 Generated with Claude Code (https://claude.ai/code)