### PR TITLE
fix: XSS対策実装とRefreshDatabase違反の修正

### DIFF
--- a/app/Models/Comment.php
+++ b/app/Models/Comment.php
@@ -50,11 +50,24 @@ class Comment extends Model
         return $query->whereNull('parent_id');
     }
 
-    // メンション表示機能（アクセサ）- 日本語対応版
+    // メンション表示機能（アクセサ）- 日本語対応版＆XSS対策
     public function getBodyWithMentionsAttribute()
     {
+        // まず危険なHTMLタグを除去（XSS対策）
+        $safeBody = strip_tags($this->body);
+        
+        // HTMLエンティティに変換（追加の安全対策）
+        $safeBody = htmlspecialchars($safeBody, ENT_QUOTES, 'UTF-8');
+        
+        // メンション部分だけをspan要素でラップ（安全なHTMLとして追加）
         // 日本語、英数字、アンダースコアに対応した正規表現
-        return preg_replace('/@([a-zA-Z0-9_\p{L}\p{N}]+)/u', '<span style="color: #1976d2; font-weight: 500; background-color: #e3f2fd; padding: 2px 4px; border-radius: 3px;">@$1</span>', $this->body);
+        $bodyWithMentions = preg_replace(
+            '/@([a-zA-Z0-9_\p{L}\p{N}]+)/u', 
+            '<span style="color: #1976d2; font-weight: 500; background-color: #e3f2fd; padding: 2px 4px; border-radius: 3px;">@$1</span>', 
+            $safeBody
+        );
+        
+        return $bodyWithMentions;
     }
 
     // このコメント配下の全ての返信を取得（YouTube風）

--- a/tests/Feature/Auth/AuthenticationTest.php
+++ b/tests/Feature/Auth/AuthenticationTest.php
@@ -4,12 +4,12 @@ namespace Tests\Feature\Auth;
 
 use App\Models\User;
 use App\Providers\RouteServiceProvider;
-use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Tests\TestCase;
 
 class AuthenticationTest extends TestCase
 {
-    use RefreshDatabase;
+    use DatabaseTransactions;
 
     public function test_login_screen_can_be_rendered(): void
     {

--- a/tests/Feature/Auth/EmailVerificationTest.php
+++ b/tests/Feature/Auth/EmailVerificationTest.php
@@ -5,14 +5,14 @@ namespace Tests\Feature\Auth;
 use App\Models\User;
 use App\Providers\RouteServiceProvider;
 use Illuminate\Auth\Events\Verified;
-use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\URL;
 use Tests\TestCase;
 
 class EmailVerificationTest extends TestCase
 {
-    use RefreshDatabase;
+    use DatabaseTransactions;
 
     public function test_email_verification_screen_can_be_rendered(): void
     {

--- a/tests/Feature/Auth/PasswordConfirmationTest.php
+++ b/tests/Feature/Auth/PasswordConfirmationTest.php
@@ -3,12 +3,12 @@
 namespace Tests\Feature\Auth;
 
 use App\Models\User;
-use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Tests\TestCase;
 
 class PasswordConfirmationTest extends TestCase
 {
-    use RefreshDatabase;
+    use DatabaseTransactions;
 
     public function test_confirm_password_screen_can_be_rendered(): void
     {

--- a/tests/Feature/Auth/PasswordResetTest.php
+++ b/tests/Feature/Auth/PasswordResetTest.php
@@ -4,13 +4,13 @@ namespace Tests\Feature\Auth;
 
 use App\Models\User;
 use Illuminate\Auth\Notifications\ResetPassword;
-use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Support\Facades\Notification;
 use Tests\TestCase;
 
 class PasswordResetTest extends TestCase
 {
-    use RefreshDatabase;
+    use DatabaseTransactions;
 
     public function test_reset_password_link_screen_can_be_rendered(): void
     {

--- a/tests/Feature/Auth/PasswordUpdateTest.php
+++ b/tests/Feature/Auth/PasswordUpdateTest.php
@@ -3,13 +3,13 @@
 namespace Tests\Feature\Auth;
 
 use App\Models\User;
-use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Support\Facades\Hash;
 use Tests\TestCase;
 
 class PasswordUpdateTest extends TestCase
 {
-    use RefreshDatabase;
+    use DatabaseTransactions;
 
     public function test_password_can_be_updated(): void
     {

--- a/tests/Feature/Auth/RegistrationTest.php
+++ b/tests/Feature/Auth/RegistrationTest.php
@@ -3,12 +3,12 @@
 namespace Tests\Feature\Auth;
 
 use App\Providers\RouteServiceProvider;
-use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Tests\TestCase;
 
 class RegistrationTest extends TestCase
 {
-    use RefreshDatabase;
+    use DatabaseTransactions;
 
     public function test_registration_screen_can_be_rendered(): void
     {

--- a/tests/Feature/ProfileTest.php
+++ b/tests/Feature/ProfileTest.php
@@ -3,12 +3,12 @@
 namespace Tests\Feature;
 
 use App\Models\User;
-use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Tests\TestCase;
 
 class ProfileTest extends TestCase
 {
-    use RefreshDatabase;
+    use DatabaseTransactions;
 
     public function test_profile_page_is_displayed(): void
     {

--- a/tests/Feature/XssProtectionTest.php
+++ b/tests/Feature/XssProtectionTest.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Comment;
+use App\Models\Post;
+use App\Models\Shop;
+use App\Models\User;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Tests\TestCase;
+
+class XssProtectionTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    protected $user;
+    protected $post;
+    protected $shop;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // テスト用データ作成
+        $this->user = User::factory()->create();
+        $this->shop = Shop::factory()->create();
+        $this->post = Post::factory()->create([
+            'user_id' => $this->user->id,
+            'shop_id' => $this->shop->id,
+        ]);
+    }
+
+    /**
+     * 危険なHTMLタグが除去されることを確認
+     */
+    public function test_dangerous_html_tags_are_removed()
+    {
+        $dangerousComment = Comment::create([
+            'user_id' => $this->user->id,
+            'post_id' => $this->post->id,
+            'body' => '<script>alert("XSS")</script>これは普通のテキスト<iframe src="evil.com"></iframe>',
+        ]);
+
+        // getBodyWithMentionsAttributeで処理された結果を取得
+        $processedBody = $dangerousComment->body_with_mentions;
+
+        // scriptタグが除去されていることを確認
+        $this->assertStringNotContainsString('<script>', $processedBody);
+        $this->assertStringNotContainsString('</script>', $processedBody);
+        
+        // iframeタグが除去されていることを確認
+        $this->assertStringNotContainsString('<iframe', $processedBody);
+        $this->assertStringNotContainsString('</iframe>', $processedBody);
+        
+        // 通常のテキストは残っていることを確認
+        $this->assertStringContainsString('これは普通のテキスト', $processedBody);
+    }
+
+    /**
+     * メンション機能が正常に動作することを確認
+     */
+    public function test_mentions_are_properly_formatted()
+    {
+        $commentWithMention = Comment::create([
+            'user_id' => $this->user->id,
+            'post_id' => $this->post->id,
+            'body' => '@田中さん こんにちは！ @yamada_123 さんもどうぞ',
+        ]);
+
+        $processedBody = $commentWithMention->body_with_mentions;
+
+        // メンションがspan要素でラップされていることを確認
+        $this->assertStringContainsString('<span style="color: #1976d2', $processedBody);
+        $this->assertStringContainsString('@田中さん', $processedBody);
+        $this->assertStringContainsString('@yamada_123', $processedBody);
+    }
+
+    /**
+     * XSS攻撃を含むメンションが安全に処理されることを確認
+     */
+    public function test_xss_in_mentions_is_prevented()
+    {
+        $xssComment = Comment::create([
+            'user_id' => $this->user->id,
+            'post_id' => $this->post->id,
+            'body' => '@<script>alert("XSS")</script> この人にメンション',
+        ]);
+
+        $processedBody = $xssComment->body_with_mentions;
+
+        // scriptタグが実行されないことを確認
+        $this->assertStringNotContainsString('<script>', $processedBody);
+        $this->assertStringNotContainsString('alert("XSS")', $processedBody);
+    }
+
+    /**
+     * HTMLエンティティが適切にエスケープされることを確認
+     */
+    public function test_html_entities_are_escaped()
+    {
+        $htmlComment = Comment::create([
+            'user_id' => $this->user->id,
+            'post_id' => $this->post->id,
+            'body' => '<div onclick="alert(1)">クリックしてください</div>',
+        ]);
+
+        $processedBody = $htmlComment->body_with_mentions;
+
+        // divタグとonclick属性が除去されていることを確認
+        $this->assertStringNotContainsString('<div', $processedBody);
+        $this->assertStringNotContainsString('onclick=', $processedBody);
+        
+        // テキスト内容は残っていることを確認
+        $this->assertStringContainsString('クリックしてください', $processedBody);
+    }
+
+    /**
+     * 複雑なXSS攻撃パターンが防御されることを確認
+     */
+    public function test_complex_xss_patterns_are_prevented()
+    {
+        $complexXss = Comment::create([
+            'user_id' => $this->user->id,
+            'post_id' => $this->post->id,
+            'body' => '<img src=x onerror="alert(1)"><svg onload="alert(2)">普通のテキスト',
+        ]);
+
+        $processedBody = $complexXss->body_with_mentions;
+
+        // 危険なタグと属性が除去されていることを確認
+        $this->assertStringNotContainsString('<img', $processedBody);
+        $this->assertStringNotContainsString('onerror=', $processedBody);
+        $this->assertStringNotContainsString('<svg', $processedBody);
+        $this->assertStringNotContainsString('onload=', $processedBody);
+        
+        // 安全なテキストは残っていることを確認
+        $this->assertStringContainsString('普通のテキスト', $processedBody);
+    }
+}


### PR DESCRIPTION
## XSS対策
- CommentモデルのgetBodyWithMentionsAttributeにXSS対策を実装
- strip_tags()とhtmlspecialchars()で危険なHTMLタグを除去
- XssProtectionTest.phpで5つのテストケースを追加

## RefreshDatabase違反の修正
- 7つのテストファイルでRefreshDatabaseをDatabaseTransactionsに変更
- 本番データ消失リスクを排除
- ProfileTest.phpとAuth系テストファイル6個を修正

🤖 Generated with [Claude Code](https://claude.ai/code)