### PR TITLE
fix: コメント削除時のリダイレクト問題を修正

### DIFF
--- a/resources/views/components/molecules/comment-card.blade.php
+++ b/resources/views/components/molecules/comment-card.blade.php
@@ -59,11 +59,15 @@ $commentId = $comment->id;
 
                 @auth
                 @if(auth()->id() === $comment->user_id || auth()->id() === $post->user_id)
-                <button @click="deleteComment" 
-                        data-comment-id="{{ $comment->id }}"
-                        class="text-neutral-600 hover:text-red-600">
-                    削除
-                </button>
+                <form action="{{ route('comments.destroy', $comment->id) }}" method="POST" style="display: inline;">
+                    @csrf
+                    @method('DELETE')
+                    <button type="submit" 
+                            class="text-neutral-600 hover:text-red-600"
+                            onclick="return confirm('このコメントを削除しますか？')">
+                        削除
+                    </button>
+                </form>
                 @endif
                 @endauth
             </div>

--- a/resources/views/post/partials/comment.blade.php
+++ b/resources/views/post/partials/comment.blade.php
@@ -23,7 +23,7 @@ if ($level <= 4) {
       @endif
 
       @if(Auth::check() && (Auth::id() === $comment->user_id || Auth::id() === $post->user_id))
-      <form action="{{ route('comments.destroy', $comment->id) }}" method="POST" style="display: inline; float: right;">
+      <form action="{{ route('comments.destroy', $comment->id) }}" method="POST" style="display: inline; float: right;" class="comment-delete-form">
         @csrf
         @method('DELETE')
         <button type="submit" class="btn btn-danger btn-small" onclick="return confirm('削除しますか？')">削除</button>


### PR DESCRIPTION
## 変更内容
- comment-card.blade.phpの削除ボタンをAlpine.jsから通常のフォーム送信に変更
- CSPビルドの制限を考慮した実装に修正
- 削除後に正しく/posts/{id}へリダイレクトされるように

## 技術的詳細
- @click="deleteComment"を削除し、通常のHTMLフォームを使用
- サーバーサイドでのリダイレクト処理を優先
- 確認ダイアログは従来通りonclick="return confirm()"で実装

🤖 Generated with [Claude Code](https://claude.ai/code)