### PR TITLE
fix: Alpine.js SRIハッシュ修正

### DIFF
--- a/resources/views/layouts/guest.blade.php
+++ b/resources/views/layouts/guest.blade.php
@@ -43,8 +43,8 @@
     @vite(['resources/css/app.css', 'resources/js/app.js'])
 
     <!-- Alpine.js -->
-    <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"
-            integrity="sha384-Dz4S7p4fiqIAslLB5RBVJuwELHZDkTYFNvLLLRVR7cGca9hgdvKXrL9lCa8IYbXy"
+    <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.14.1/dist/cdn.min.js"
+            integrity="sha384-l8f0VcPi/M1iHPv8egOnY/15TDwqgbOR1anMIJWvU6nLRgZVLTLSaNqi/TOoT5Fh"
             crossorigin="anonymous"></script>
 
     <!-- Google Maps API -->


### PR DESCRIPTION
- Alpine.jsを3.14.1に固定（3.x.xから変更）
- 正しいSHA-384ハッシュ値を設定
- SRIエラーによるリソースブロックを解消